### PR TITLE
Ra3 - HA integration compatibility

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -672,6 +672,7 @@ class Smartbridge:
             type=zone_type,
             model=processor_json["ModelNumber"],
             serial=processor_json["SerialNumber"],
+        )
 
         
     async def _load_ra3_control_stations(self, area):

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -656,22 +656,23 @@ class Smartbridge:
             return
         
         processor_json = processor_json.Body["Devices"]
+        processor = processor_json[0]
         
         level = -1
         device_id = "1"
         fan_speed = None
-        device_name = processor_json["Name"]
+        device_name = processor["Name"]
         zone_type = None
         self.devices.setdefault(
             device_id,
             {"device_id": device_id, "current_state": level, "fan_speed": fan_speed},
         ).update(
             zone=device_id,
-            name=processor_json["Name"],
+            name=processor["Name"],
             button_groups=None,
             type=zone_type,
-            model=processor_json["ModelNumber"],
-            serial=processor_json["SerialNumber"],
+            model=processor["ModelNumber"],
+            serial=processor["SerialNumber"],
         )
 
         

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -658,7 +658,7 @@ class Smartbridge:
         processor_json = processor_json.Body["Devices"]
         
         level = -1
-        device_id = 1
+        device_id = "1"
         fan_speed = None
         device_name = processor_json["Name"]
         zone_type = None

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -731,7 +731,7 @@ class Smartbridge:
             button_groups=button_groups,
             type=device_type,
             model=device_model,
-            serial=None,
+            serial="_".join((name, device_name)),
         )
 
         for button_expanded_json in button_group_json.Body["ButtonGroupsExpanded"]:
@@ -763,7 +763,7 @@ class Smartbridge:
             name=device["name"].split("_")[1],
             type=device["type"],
             model=device["model"],
-            serial=None,
+            serial=device["name"].split("_")[1],
             button_name=button_name,
             button_led=button_led,
         )
@@ -792,7 +792,7 @@ class Smartbridge:
                 button_groups=None,
                 type=zone_type,
                 model=None,
-                serial=None,
+                serial="_".join((area["name"], zone_name)),
             )
 
     async def _load_lip_devices(self):


### PR DESCRIPTION
These changes accomplish compatibility with the Home Assistant lutron_caseta integration

Added a function to add RA3 Processor details to devices["1"], so the HA integration can complete the component setup.

Added assigning the serial of the area and zone name for: zones, buttons, station_device

The HA integration uses the serial to establish a unique id for each entity.  When using none, we aren't able to reference all of the zones.  By assigning the area and zone name as serial, the integration can complete the setup, and each zone functions properly.  At least for lighting and my pico buttons.  I don't have any occupancy or shades to test with yet.

I think this probably makes sense to use the area+zone name instead of serial number anyway.  You can imagine, If we were to swap out a RRD-PRO for a Sunnata dimmer in the same zone, maybe due to switch failure, we would probably want the HA entity to remain the same.  If we use the actual dimmer serial number, we'd end up with a different entity.  (ie basement_bedroom_main_lights would become basement_bedroom_main_lights2). 
